### PR TITLE
Force creation of symlinks on (re)install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,14 +36,14 @@ hostfiles :
 
 install : qdv
 	mkdir -p $(CFG_DIR)
-	ln -s $(shell pwd)/XLX_Hosts.txt $(CFG_DIR)
-	ln -s $(shell pwd)/DExtra_Hosts.txt $(CFG_DIR)
-	ln -s $(shell pwd)/DCS_Hosts.txt $(CFG_DIR)
-	ln -s $(shell pwd)/DPlus_Hosts.txt $(CFG_DIR)
-	ln -s $(shell pwd)/announce $(CFG_DIR)
-	ln -s $(shell pwd)/DigitalVoice.glade $(CFG_DIR)
+	ln -sf $(shell pwd)/XLX_Hosts.txt $(CFG_DIR)
+	ln -sf $(shell pwd)/DExtra_Hosts.txt $(CFG_DIR)
+	ln -sf $(shell pwd)/DCS_Hosts.txt $(CFG_DIR)
+	ln -sf $(shell pwd)/DPlus_Hosts.txt $(CFG_DIR)
+	ln -sf $(shell pwd)/announce $(CFG_DIR)
+	ln -sf $(shell pwd)/DigitalVoice.glade $(CFG_DIR)
 	mkdir -p $(BIN_DIR)
-	ln -s $(shell pwd)/qdv $(BIN_DIR)
+	ln -sf $(shell pwd)/qdv $(BIN_DIR)
 
 #interactive :
 #	GTK_DEBUG=interactive ./qdv


### PR DESCRIPTION
If the symlinks exist in `~/bin` or `.config`, make install will fail.  Add the `-f` argument to force replacement of the destination files.

But longer term, I am not sure symlinking is a good solution. It might be better to copy.